### PR TITLE
PR: Update SocialShare.astro to call the right Whatsapp.astro

### DIFF
--- a/src/SocialShare.astro
+++ b/src/SocialShare.astro
@@ -5,7 +5,7 @@ import HackerNewsShareButton from "./HackerNews.astro";
 import LinkedInShareButton from "./LinkedIn.astro";
 import RedditShareButton from "./Reddit.astro";
 import TwitterShareButton from './Twitter.astro';
-import WhatsAppShareButton from './WhatsApp.astro';
+import WhatsAppShareButton from './Whatsapp.astro';
 import type ButtonProps  from './types';
 
 interface Props extends ButtonProps {


### PR DESCRIPTION
## Bug

- SocialShare.astro is trying to import WhatsApp.astro when it's actually Whatsapp.astro - which breaks on Case Sensitive Operating Systems. 

## Fix

- Call ``Whatsapp.astro`` instead of ``WhatsApp.astro``